### PR TITLE
Removes Firebase Import

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,8 +510,7 @@
         </div>
         <p> &copy; <a target="_blank" rel="noopener noreferrer" href="https://creatorscollective.club">i_wanna_b_the_guy</a> 2017 </p>
     </footer>
-
-    <script src="https://www.gstatic.com/firebasejs/4.4.0/firebase.js"></script>
+    
     <script src="./js/vendor/jquery-3.3.1.slim.min.js"></script>
     <script src="./js/vendor/bootstrap.min.js?v4.4.1"></script>
 


### PR DESCRIPTION
Was just taking a cursory look at the v1 webpage and noticed that we still import Firebase. I believe (but am not certain) that we don't use it anymore - can you confirm @weblue? If we don't, we shouldn't load it as a resource (as it'll increase bandwidth + stop meaningful renders).

(this PR is a one-line change that just removes it).