### PR TITLE
Updating setup-node action, Node LTS, & Naming

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,9 +4,9 @@ name: Lint thelist.json
 
 on:
   push:
-    branches: [ master, angular2 ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, angular2 ]
+    branches: [ master ]
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
     - run: node checkJson.js

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,13 +1,13 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Build Angular App
 
 on:
   push:
-    branches: [ master, angular2 ]
+    branches: [ master]
   pull_request:
-    branches: [ master, angular2 ]
+    branches: [ master ]
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
Addressing [CVE on GitHub Actions](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), updating node dependency! Shifts from `12.x, 14.x` to `14.x, 15.x`.

(also renames some things for clarity)