### PR TITLE
Re-adds 404 fallback

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,6 +28,10 @@ jobs:
       run: npm ci
     - name: Build
       run: npm run build --if-present
+    - name: Create index.html Fallback
+      # this next step makes all routes go to index.html for GitHub Pages
+      # for more, see https://angular.io/guide/deployment#routed-apps-must-fallback-to-indexhtml
+      run: cp dist/tierlist/index.html dist/tierlist/404.html
     - name: Validate
       run: npm test
 


### PR DESCRIPTION
As pointed out in #78, the current app no longer allows links that aren't rooted at `/`. This is likely because we forgot to copy over the `404.html` copying when switching to GitHub Actions. This re-adds it as a step in the deploy action.

(maybe we should add this to the `build` script?)